### PR TITLE
chore: bump Node to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: false
   continue-on-error:
     required: false
-    description: 'Whether or not the action should set the failure status if the plan fails.  This will not affect the check being set witht he plan results.'
+    description: 'Whether or not the action should set the failure status if the plan fails.  This will not affect the check being set with the plan results.'
     default: false
   report-title:
     required: false
@@ -28,5 +28,5 @@ inputs:
     description: 'The directory path to store the full stdout / stderr from the terraform plan execution.  A std.out and std.err file will be created with the data.'
     default: ''
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
[HXCE-376](https://alfresco.atlassian.net/browse/HXCE-376)

Bumps the now-obsolete Node 12 to 16 so that the action won't break when GitHub removes support for Node 12 in Summer 2023 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).